### PR TITLE
Do not clear suggestions on click.

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -233,7 +233,9 @@ export default class Autocomplete extends Component {
           validChoiceMade: false
         })
       })
-    } else {
+    }
+
+    if (!queryLongEnough) {
       source('', (options) => {
         const optionsAvailable = options.length > 0
         this.setState({


### PR DESCRIPTION
`handleInputChange` fires on click and so clears the suggestion
dropdown as the query hasn't changed.

Relates to: ac0163588865e449a175d2ea0b5a9b34ee47d804