### PR TITLE
Correct CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
-
-    # This file was automatically created by the biz-ops-github-importer.
-    # Please correct the ownership stated below if it is wrong.
-    @Financial-Times/origami-core
+# This file was automatically created by the biz-ops-github-importer.
+# Please correct the ownership stated below if it is wrong.
+* @Financial-Times/origami-core


### PR DESCRIPTION
Fix a bug in the automated creation on the CODEOWNERS file which led to the leading asterisk being missing.