### PR TITLE
Add query parameter to templateSuggestion function

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Type:
 
 This object defines templates (functions) that are used for displaying parts of the autocomplete.
 
-`inputValue` is a function that receives one argument, the currently selected suggestion. It returns the string value to be inserted into the input.
+`inputValue` is a function that receives two arguments: the currently selected suggestion and the query value (the latter to use as a basis for highlighting the suggestion). It returns the string value to be inserted into the input.
 
 `suggestion` is a function that receives one argument, a suggestion to be displayed. It is used when rendering suggestions, and should return a string, which can contain HTML. :warning: **Caution:** because this function allows you to output arbitrary HTML, you should [make sure it's trusted](https://en.wikipedia.org/wiki/Cross-site_scripting), and accessible.
 

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -153,9 +153,9 @@ export default class Autocomplete extends Component {
   }
 
   // This template is used when displaying results / suggestions.
-  templateSuggestion (value) {
+  templateSuggestion (value, query) {
     const suggestionTemplate = this.props.templates && this.props.templates.suggestion
-    return suggestionTemplate ? suggestionTemplate(value) : value
+    return suggestionTemplate ? suggestionTemplate(value, query) : value
   }
 
   handleComponentBlur (newState) {
@@ -544,7 +544,7 @@ export default class Autocomplete extends Component {
               <li
                 aria-selected={focused === index ? 'true' : 'false'}
                 className={`${optionClassName}${optionModifierFocused}${optionModifierOdd}`}
-                dangerouslySetInnerHTML={{ __html: this.templateSuggestion(option) + iosPosinsetHtml }}
+                dangerouslySetInnerHTML={{ __html: this.templateSuggestion(option, query) + iosPosinsetHtml }}
                 id={`${id}__option--${index}`}
                 key={index}
                 onBlur={(event) => this.handleOptionBlur(event, index)}


### PR DESCRIPTION
This PR modifies the `templateSuggestion` function to take an additional `query` parameter (the text which was typed into the autocomplete text input field by the user).

This means that the Origami o-autocomplete component (which relies on accessible-autocomplete) can provide a `suggestionTemplate` in the options when instantiating an instance of `oAutocomplete` which can use that `query` value in its callback.

This will enable a customised rendering of suggestion items whilst retaining the ability to apply highlighting (for which the `query` value is necessary, on the `option` value (or, in the scenario of it being an object, values thereof)).

#### Dependent PRs (i.e. they will need to consume the release that includes this PR's changes)
- TBC

#### Release
This adds functionality in a backwards-compatible manner so I propose to release these changes as a **minor** version.