### PR TITLE
Add query arg to suggestionTemplate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ This object defines templates (functions) that are used for displaying parts of 
 
 `inputValue` is a function that receives one argument, the currently selected suggestion. It returns the string value to be inserted into the input.
 
-`suggestion` is a function that receives one argument, a suggestion to be displayed. It is used when rendering suggestions, and should return a string, which can contain HTML.
+`suggestion` is a function that receives two arguments, a suggestion to be displayed and the query value (the latter to use as a basis for highlighting the suggestion). It is used when rendering suggestions, and should return a string, which can contain HTML.
 
 :warning: **Caution:** because this function allows you to output arbitrary HTML, you should [make sure it's trusted](https://en.wikipedia.org/wiki/Cross-site_scripting), and accessible.
 

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -157,9 +157,9 @@ export default class Autocomplete extends Component {
   }
 
   // This template is used when displaying results / suggestions.
-  templateSuggestion (value) {
+  templateSuggestion (value, query) {
     const suggestionTemplate = this.props.templates && this.props.templates.suggestion
-    return suggestionTemplate ? suggestionTemplate(value) : value
+    return suggestionTemplate ? suggestionTemplate(value, query) : value
   }
 
   handleComponentBlur (newState) {
@@ -586,7 +586,7 @@ export default class Autocomplete extends Component {
               <li
                 aria-selected={focused === index ? 'true' : 'false'}
                 className={`${optionClassName}${optionModifierFocused}${optionModifierOdd}`}
-                dangerouslySetInnerHTML={{ __html: this.templateSuggestion(option) + iosPosinsetHtml }}
+                dangerouslySetInnerHTML={{ __html: this.templateSuggestion(option, query) + iosPosinsetHtml }}
                 id={`${id}__option--${index}`}
                 key={index}
                 onBlur={(event) => this.handleOptionBlur(event, index)}


### PR DESCRIPTION
This PR modifies the `templateSuggestion` function to take an additional `query` parameter (the text which was typed into the autocomplete text input field by the user).

This means that the Origami o-autocomplete component (which relies on accessible-autocomplete) can provide a `suggestionTemplate` in the options when instantiating an instance of `oAutocomplete` which can use that `query` value in its callback.

This will enable a customised rendering of suggestion items whilst retaining the ability to apply highlighting (for which the `query` value is necessary) on the `option` value (or, in the scenario of it being an object, values thereof).

#### Dependent PRs
- https://github.com/Financial-Times/accessible-autocomplete/pull/28

#### Dependent PRs
- https://github.com/Financial-Times/origami/pull/1516

#### TODO
- [ ] If possible, make this same PR against the source repo (https://github.com/alphagov/accessible-autocomplete) — I do not have write permissions (`ERROR: Permission to alphagov/accessible-autocomplete.git denied to andygout`), and based on this [commit](https://github.com/alphagov/accessible-autocomplete/pull/491/commits/a6c2d4f7649d9d2dd6e1c6c43d0655466ce3a062), I think only Jake Champion had them, @notlee? Though it may not be reviewed in any case based on https://github.com/alphagov/accessible-autocomplete/issues/430.
  - This is with an aim to deleting this repo and using that source repo as o-autocomplete's dependency (more detail here: https://github.com/Financial-Times/accessible-autocomplete/pull/28).

#### Release
This adds functionality in a backwards-compatible manner so I propose to release these changes as a **minor** version.